### PR TITLE
Game path detection for EGS

### DIFF
--- a/getGacha.ps1
+++ b/getGacha.ps1
@@ -15,7 +15,7 @@ $method = "automatic"
 #EGS Version or Fallback to Manual
 if (!$gamePath -or !$gachaLogPathExists) {
     $currentUserSID = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
-    $muiCachePath = "Registry::HKEY_USERS\$currentUserSID\Software\Classes\Local Settings\Software\Microsoft\Windows\Shell\MuiCache"
+    $muiCachePath = "Registry::HKEY_CURRENT_USER\Software\Classes\Local Settings\Software\Microsoft\Windows\Shell\MuiCache"
     $filteredEntries = (Get-ItemProperty -Path $muiCachePath).PSObject.Properties | Where-Object { $_.Value -like "*wuthering*" }
     if ($filteredEntries.Count -ne 0) {
         $gachaLogPath = ($filteredEntries[0].Name -split 'client-win64-shipping')[0] + "ThirdParty\KrPcSdk_Global\KRSDKRes\KRSDKWebView"

--- a/getGacha.ps1
+++ b/getGacha.ps1
@@ -14,9 +14,8 @@ $method = "automatic"
 
 #EGS Version or Fallback to Manual
 if (!$gamePath -or !$gachaLogPathExists) {
-    $currentUserSID = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
     $muiCachePath = "Registry::HKEY_CURRENT_USER\Software\Classes\Local Settings\Software\Microsoft\Windows\Shell\MuiCache"
-    $filteredEntries = (Get-ItemProperty -Path $muiCachePath).PSObject.Properties | Where-Object { $_.Value -like "*wuthering*" }
+    $filteredEntries = (Get-ItemProperty -Path $muiCachePath).PSObject.Properties | Where-Object { $_.Value -like "*wuthering*" } | Where-Object {$_.Name -like "*client-win64-shipping.exe*"}
     if ($filteredEntries.Count -ne 0) {
         $gachaLogPath = ($filteredEntries[0].Name -split 'client-win64-shipping')[0] + "ThirdParty\KrPcSdk_Global\KRSDKRes\KRSDKWebView"
     }
@@ -46,38 +45,38 @@ if (!$gamePath -or !$gachaLogPathExists) {
             Write-Output "Invalid game path. Please try again."
         }
         $gachaLogPath = $gamePath + '\Wuthering Waves Game\Client\Binaries\Win64\ThirdParty\KrPcSdk_Global\KRSDKRes\KRSDKWebView'
+	}
+}
+if (Test-Path ($gachaLogPath + "\debug.log") -PathType Leaf) {
+    Write-Output "Finding Gacha Url..."
+
+    Copy-Item -Path ($gachaLogPath + "\debug.log") -Destination ($gachaLogPath + "\debug_copy.log")
+    $cacheData = Get-Content ($gachaLogPath + "\debug.log")
+    Remove-Item -Path ($gachaLogPath + "\debug_copy.log")
+    $cacheDataLines = $cacheData -split '1/0/'
+    $url = ""
+
+    for ($i = $cacheDataLines.Length - 1; $i -ge 0; $i--) {
+        $line = $cacheDataLines[$i]
+
+        if ($line.Contains("https://aki-gm-resources-oversea.aki-game.net/aki/gacha/index.html#/record")) {
+            $url = (($line -split ': "')[1].replace('",', "")) + ("&wa_method=" + $method)
+
+            break
+        }
     }
-    if (Test-Path ($gachaLogPath + "\debug.log") -PathType Leaf) {
-        Write-Output "Finding Gacha Url..."
 
-        Copy-Item -Path ($gachaLogPath + "\debug.log") -Destination ($gachaLogPath + "\debug_copy.log")
-        $cacheData = Get-Content ($gachaLogPath + "\debug.log")
-        Remove-Item -Path ($gachaLogPath + "\debug_copy.log")
-        $cacheDataLines = $cacheData -split '1/0/'
-        $url = ""
-
-        for ($i = $cacheDataLines.Length - 1; $i -ge 0; $i--) {
-            $line = $cacheDataLines[$i]
-
-            if ($line.Contains("https://aki-gm-resources-oversea.aki-game.net/aki/gacha/index.html#/record")) {
-                $url = (($line -split ': "')[1].replace('",', "")) + ("&wa_method=" + $method)
-
-                break
-            }
-        }
-
-        if ($url) {
-            Write-Output " "
-            Write-Output $url
-            Set-Clipboard -Value $url
-            Write-Output " "
-            Write-Output "Gacha Url has been saved to clipboard."
-        }
-        else {
-            Write-Output "Unable to find Gacha Url. Please open Convene Records in game."
-        }
+    if ($url) {
+        Write-Output " "
+        Write-Output $url
+        Set-Clipboard -Value $url
+        Write-Output " "
+        Write-Output "Gacha Url has been saved to clipboard."
     }
     else {
         Write-Output "Unable to find Gacha Url. Please open Convene Records in game."
     }
+}
+else {
+    Write-Output "Unable to find Gacha Url. Please open Convene Records in game."
 }

--- a/getGacha.ps1
+++ b/getGacha.ps1
@@ -4,72 +4,80 @@ $ProgressPreference = 'SilentlyContinue'
 #Find Game
 Write-Output "Attempting to find game path automatically..."
 
+#Native Version
 $64 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*"
 $32 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*"
 $gamePath = (Get-ItemProperty -Path $32, $64 | Where-Object { $_.DisplayName -like "*wuthering*" } | Select InstallPath).PSObject.Properties.Value
-$gachaLogPathExists = Test-Path ($gamePath + '\Wuthering Waves Game\Client\Binaries\Win64\ThirdParty\KrPcSdk_Global\KRSDKRes\KRSDKWebView')
+$gachaLogPath = $gamePath + '\Wuthering Waves Game\Client\Binaries\Win64\ThirdParty\KrPcSdk_Global\KRSDKRes\KRSDKWebView'
+$gachaLogPathExists = Test-Path ($gachaLogPath )
 $method = "automatic"
 
+#EGS Version or Fallback to Manual
 if (!$gamePath -or !$gachaLogPathExists) {
-    $method = "manual"
-
-    Write-Output " "
-    Write-Output "Couldn't automatically find game path. Please enter game path manually."
-    Write-Output "Ex. E:\Wuthering Waves"
-    Write-Output " "
-
-    $path = read-host "Game path: "
-
-    if ($path) {
-        if ($path.EndsWith("Wuthering Waves")) {
-            $gamePath = $path
-            Write-Output "Manually found game path."
-        } elseif ($path.EndsWith("Wuthering Waves Game")) {
-            $gamePath = $path.replace("Wuthering Waves Game", "")
-            Write-Output "Manually found game path."
-        } else {
+    $currentUserSID = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+    $muiCachePath = "Registry::HKEY_USERS\$currentUserSID\Software\Classes\Local Settings\Software\Microsoft\Windows\Shell\MuiCache"
+    $filteredEntries = (Get-ItemProperty -Path $muiCachePath).PSObject.Properties | Where-Object { $_.Value -like "*wuthering*" }
+    if ($filteredEntries.Count -ne 0) {
+        $gachaLogPath = ($filteredEntries[0].Name -split 'client-win64-shipping')[0] + "ThirdParty\KrPcSdk_Global\KRSDKRes\KRSDKWebView"
+    }
+    else {
+        $method = "manual"
+        Write-Output " "
+        Write-Output "Couldn't automatically find game path. Please enter game path manually."
+        Write-Output "Ex. E:\Wuthering Waves"
+        Write-Output " "
+    
+        $path = read-host "Game path: "
+    
+        if ($path) {
+            if ($path.EndsWith("Wuthering Waves")) {
+                $gamePath = $path
+                Write-Output "Manually found game path."
+            }
+            elseif ($path.EndsWith("Wuthering Waves Game")) {
+                $gamePath = $path.replace("Wuthering Waves Game", "")
+                Write-Output "Manually found game path."
+            }
+            else {
+                Write-Output "Invalid game path. Please try again."
+            }
+        }
+        else {
             Write-Output "Invalid game path. Please try again."
         }
-    } else {
-        Write-Output "Invalid game path. Please try again."
+        $gachaLogPath = $gamePath + '\Wuthering Waves Game\Client\Binaries\Win64\ThirdParty\KrPcSdk_Global\KRSDKRes\KRSDKWebView'
     }
-} else {
-    Write-Output "Automatically found game path."
-}
+    if (Test-Path ($gachaLogPath + "\debug.log") -PathType Leaf) {
+        Write-Output "Finding Gacha Url..."
 
-Write-Output " "
+        Copy-Item -Path ($gachaLogPath + "\debug.log") -Destination ($gachaLogPath + "\debug_copy.log")
+        $cacheData = Get-Content ($gachaLogPath + "\debug.log")
+        Remove-Item -Path ($gachaLogPath + "\debug_copy.log")
+        $cacheDataLines = $cacheData -split '1/0/'
+        $url = ""
 
-$gachaLogPath = $gamePath + '\Wuthering Waves Game\Client\Binaries\Win64\ThirdParty\KrPcSdk_Global\KRSDKRes\KRSDKWebView'
+        for ($i = $cacheDataLines.Length - 1; $i -ge 0; $i--) {
+            $line = $cacheDataLines[$i]
 
-#Find Gacha Url
-if (Test-Path ($gachaLogPath + "\debug.log") -PathType Leaf) {
-    Write-Output "Finding Gacha Url..."
+            if ($line.Contains("https://aki-gm-resources-oversea.aki-game.net/aki/gacha/index.html#/record")) {
+                $url = (($line -split ': "')[1].replace('",', "")) + ("&wa_method=" + $method)
 
-    Copy-Item -Path ($gachaLogPath + "\debug.log") -Destination ($gachaLogPath + "\debug_copy.log")
-    $cacheData = Get-Content ($gachaLogPath + "\debug.log")
-    Remove-Item -Path ($gachaLogPath + "\debug_copy.log")
-    $cacheDataLines = $cacheData -split '1/0/'
-    $url = ""
+                break
+            }
+        }
 
-    for ($i = $cacheDataLines.Length - 1; $i -ge 0; $i--) {
-        $line = $cacheDataLines[$i]
-
-        if ($line.Contains("https://aki-gm-resources-oversea.aki-game.net/aki/gacha/index.html#/record")) {
-            $url = (($line -split ': "')[1].replace('",', "")) + ("&wa_method=" + $method)
-
-            break
+        if ($url) {
+            Write-Output " "
+            Write-Output $url
+            Set-Clipboard -Value $url
+            Write-Output " "
+            Write-Output "Gacha Url has been saved to clipboard."
+        }
+        else {
+            Write-Output "Unable to find Gacha Url. Please open Convene Records in game."
         }
     }
-
-    if ($url) {
-        Write-Output " "
-        Write-Output $url
-        Set-Clipboard -Value $url
-        Write-Output " "
-        Write-Output "Gacha Url has been saved to clipboard."
-    } else {
+    else {
         Write-Output "Unable to find Gacha Url. Please open Convene Records in game."
     }
-} else {
-    Write-Output "Unable to find Gacha Url. Please open Convene Records in game."
 }


### PR DESCRIPTION
Adding to #1 
Support automatic game path detection for EGS version (possible all?) by searching in Registry's MUI Cache entries for game's executable path. 
From what I could tell MUI cache is used for language localisation and is available in Registry after first launch of the game and persists until manually deleted or in a recovery scenario. It is available under 
> Registry::HKEY_CURRENT_USER\Software\Classes\Local Settings\Software\Microsoft\Windows\Shell\MuiCache

![image](https://github.com/alpharmi/wuthering.app/assets/78343648/2cba0283-9d10-4534-9249-fd313452036d)

The script still checks registry paths for uninstall entries first and then checks in MUI Cache as I am unsure if native version have these entries as well.  If everything fails falls back to manual method.